### PR TITLE
modify error handling

### DIFF
--- a/module.py
+++ b/module.py
@@ -735,7 +735,7 @@ def updateLocalGitRepo(user, repo, path, branch='master'):
 
         if os.path.exists(path):
             shutil.rmtree(path)
-        os.makedirs(path)
+        # os.makedirs(path)
 
         if os.path.exists(tmpPath):
             shutil.rmtree(tmpPath)

--- a/module.py
+++ b/module.py
@@ -1182,6 +1182,7 @@ def main():
     except:
         print(traceback.format_exc())
         info("Error during execution of update script.")
+        info("Please try once more.")
         sys.exit(1)
     else:
         info('~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n')

--- a/module.py
+++ b/module.py
@@ -418,13 +418,16 @@ def unzipOnHost(zipFile, remotePath):
 
 def configureDpkg():
     info('Configuring dpkg ... ')
-    output, retcode = runSshCommand(
-        'DEBIAN_FRONTEND=noninteractive sudo dpkg --configure -a --force-confold --force-confdef')
+    cmd = 'DEBIAN_FRONTEND=noninteractive sudo dpkg --configure -a --force-confold --force-confdef'
+    output, retcode = runSshCommand(cmd)
     if retcode != 0:
-        exitScript(' failed\n')
-        return
-    else:
-        info('done\n')
+        time.sleep(5)  # wait in case of dpkg lock for example
+        output, retcode = runSshCommand(cmd)
+        if retcode != 0:
+            exitScript(' failed, please try again later\n')
+            return
+
+    info('done\n')
 
 
 def checkPackage(name):


### PR DESCRIPTION
Retry dpkg once in case it fails because of a temporary lock for example.
Remove a duplicate line of code that can fail.
Suggest to the user to try again, in case of intermittent fault for example.